### PR TITLE
Use direct path to rvm installer

### DIFF
--- a/puphpet/puppet/modules/rvm/manifests/system.pp
+++ b/puphpet/puppet/modules/rvm/manifests/system.pp
@@ -21,7 +21,7 @@ class rvm::system(
 
   exec { 'system-rvm':
     path        => '/usr/bin:/usr/sbin:/bin',
-    command     => "/usr/bin/curl -fsSL https://get.rvm.io | bash -s -- --version ${actual_version}",
+    command     => "/usr/bin/curl -sSL https://raw.githubusercontent.com/wayneeseguin/rvm/master/binscripts/rvm-installer | bash -s -- --version ${actual_version}",
     creates     => '/usr/local/rvm/bin/rvm',
     environment => $proxy_url ? { undef => undef, default => [ "http_proxy=${proxy_url}" , "https_proxy=${proxy_url}" ]},
   }

--- a/puphpet/shell/install-ruby.sh
+++ b/puphpet/shell/install-ruby.sh
@@ -22,7 +22,8 @@ elif [[ "${OS}" == 'centos' ]]; then
     gpg2 --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys D39DC0E3
 fi
 
-curl -sSL https://get.rvm.io | bash -s stable --quiet-curl --ruby=ruby-1.9.3-p551
+curl -sSL https://raw.githubusercontent.com/wayneeseguin/rvm/master/binscripts/rvm-installer | bash -s stable --quiet-curl --ruby=ruby-1.9.3-p551
+
 
 source /usr/local/rvm/scripts/rvm
 


### PR DESCRIPTION
Use direct path to rvm installer instead of relying on rvm.io(which is down at this moment)